### PR TITLE
Fix dev server on Windows

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,13 +5,14 @@
   "scripts": {
     "build": "tsc --p ./tsconfig.prod.json",
     "preview": "node ./dist/index.js",
-    "dev": "NODE_ENV=development nodemon index.ts",
+    "dev": "cross-env NODE_ENV=development nodemon index.ts",
     "lint": "eslint .",
     "format": "prettier --write .",
     "test": "jest ."
   },
   "dependencies": {
     "cors": "^2.8.5",
+    "cross-env": "^7.0.3",
     "dotenv": "^16.0.2",
     "eslint-config-prettier": "^8.5.0",
     "express": "^4.18.1",


### PR DESCRIPTION
### Какую задачу решаем
Запуск шаблона под Windows. 

Такая конструкция под Windows не работает:
```
"dev": "NODE_ENV=development nodemon index.ts",
```
получаем ошибку:
```
$ node_modules\.bin\yarn dev --scope=server
```

```sh
yarn run v1.22.19
$ lerna run dev --scope=server
lerna notice cli v5.4.3
lerna notice filter including "server"
lerna info filter [ 'server' ]

> server:dev

$ NODE_ENV=development nodemon index.ts
'NODE_ENV' is not recognized as an internal or external command,
operable program or batch file.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.

 ——————————————————————————————————————

 >  Lerna (powered by Nx)   Running target "server:dev" failed
```

Добавил установку окружения через пакет `cross-env`
