### PR TITLE
fix jest on windows

### DIFF
--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -4,7 +4,7 @@ dotenv.config()
 export default {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
-  testMatch: ['<rootDir>/src/**/?(*.)test.{ts,tsx}'],
+  testMatch: ['<rootDir>/src/**/*.test.{ts,tsx}'],
   globals: {
     __SERVER_PORT__: process.env.SERVER_PORT,
   },


### PR DESCRIPTION
### Какую задачу решаем

Исправлена ошибка запуска `yarn test` под Windows

```E:\PROJECTS\__1\deadem>yarn test
yarn run v1.22.19
$ lerna run test 
lerna notice cli v5.4.3
 ×  client:test      
 $ jest ./
  No tests found, exiting with code 1 
  Run with `--passWithNoTests` to exit with code 0  
  In E:\PROJECTS\__1\deadem\packages\client  
    10 files checked.
    testMatch: E:/PROJECTS/__1/deadem/packages/client/src/**\?(*.)test.{ts,tsx} - 0 matches   
    testPathIgnorePatterns: \\node_modules\\ - 10 matches  
    testRegex:  - 0 matches    
  Pattern: .\\ - 0 matches     
  error Command failed with exit code 1.     
  info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command. 
      √  server:test (5s)
————————————————————————————————————————————————
>  Lerna (powered by Nx)   Ran target test for 2 projects (5s)
 √    1/2 succeeded [0 read from cache]
 ×    1/2 targets failed, including the following:  
      - client:test

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```