### PR TITLE
Исключаем лишние файлы из Docker образа

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Игнорировать установленные node.js модули
+node_modules
+
+# Игнорировать файлы и папки, связанные с Git
+.git
+.gitignore
+
+# Игнорировать файлы конфигурации
+/.env*
+
+# Игнорировать файлы, необходимые только для разработки
+.DS_Store
+.vscode
+
+# Игнорировать файлы описания Docker-контейнеров и Compose
+Dockerfile*
+docker-compose*.yml
+
+# Игнорировать файлы, связанные с eslint
+.eslintignore
+.eslintrc*
+
+# Игнорировать файлы, связанные с prettier и editorconfig и lefthook
+.prettierignore
+.prettierrc
+.editorconfig
+lefthook.yml
+
+# Игнорировать файл с описанием репозитория
+/README.md

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -18,10 +18,10 @@ RUN rm -rf /app/packages/server/dist/ && yarn build --scope=server
 
 FROM node:$NODE_VERSION-buster-slim as production
 WORKDIR /app
-
+ENV NODE_ENV production
 COPY --from=builder /app/packages/server/dist/ /app/
 COPY --from=builder /app/packages/server/package.json /app/package.json
-RUN yarn install --production=true
-
+RUN yarn && \
+    yarn cache clean
 EXPOSE $SERVER_PORT
 CMD [ "node", "/app/index.js" ]


### PR DESCRIPTION
### Какую задачу решаем

Сейчас в финальный прод образ для сервера попадает кэш yarn и конфиги dev-тулз, git-коммитов и секреты из .env, что не совсем хорошо. 
Исправил это доброской .dockerignore файла и очисткой кэша yarn в том же слое что и установка зависимостей